### PR TITLE
[IMP] ArtificialHttpServletRequest support to operate attributes

### DIFF
--- a/modules/blocks/roll-export/src/main/java/io/github/springroll/export/excel/ExportExcelController.java
+++ b/modules/blocks/roll-export/src/main/java/io/github/springroll/export/excel/ExportExcelController.java
@@ -103,7 +103,7 @@ public class ExportExcelController {
 
         Map<String, String[]> params = parseParams(decodedUrl);
         ArtificialHttpServletRequest bizRequest = new ArtificialHttpServletRequest(contextPath, servletPath, cleanUrl);
-        bizRequest.setParams(params);
+        bizRequest.setParameters(params);
 
         String decodedCols = decode(cols, tomcatUriEncoding);
         LOGGER.debug("Cols string after encoding is {}", decodedCols);

--- a/modules/blocks/roll-export/src/test/groovy/io/github/springroll/export/excel/ExportExcelControllerTest.groovy
+++ b/modules/blocks/roll-export/src/test/groovy/io/github/springroll/export/excel/ExportExcelControllerTest.groovy
@@ -11,11 +11,7 @@ import org.junit.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.util.NestedServletException
 
 import javax.servlet.http.HttpServletRequest
@@ -81,7 +77,7 @@ class ExportExcelControllerTest extends AbstractSpringTest {
         def title = URLEncoder.encode('中文post','utf-8')
         def model = [
                 cols: [["prop":"name","label":"名称"],["prop":"des","label":"描述"],["label":"无prop","other": "props"]],
-                url: '/test/query/post',
+                url: '/test/query/post/plant_name/plant_des',
                 bizReqBody: [
                     name: "body name",
                     des: "body des"
@@ -149,9 +145,11 @@ class Controller extends BaseController {
         [rows: ['Jordan', 'Kobe']]
     }
 
-    @PostMapping('/post')
-    Map<String, List<Planet>> post(@RequestBody Planet planet) {
-        ['rows': [planet]]
+    @PostMapping('/post/{name}/{des}')
+    Map<String, List<Planet>> post(@PathVariable String name, @PathVariable String des, @RequestBody Planet planet) {
+        def planet2 = new Planet(name)
+        planet2.setDes(des)
+        ['rows': [planet, planet2]]
     }
 
 }

--- a/modules/blocks/roll-export/src/test/groovy/io/github/springroll/export/excel/ExportExcelControllerTest.groovy
+++ b/modules/blocks/roll-export/src/test/groovy/io/github/springroll/export/excel/ExportExcelControllerTest.groovy
@@ -86,7 +86,7 @@ class ExportExcelControllerTest extends AbstractSpringTest {
                 tomcatUriEncoding: 'utf-8'
         ]
         def response = post("/export/excel/$title", JsonUtil.toJsonIgnoreException(model), HttpStatus.OK).getResponse()
-        checkResponse(response, title, 1)
+        checkResponse(response, title, 2)
     }
 
 }

--- a/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
+++ b/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
@@ -27,25 +27,34 @@ import java.util.*;
 public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     private static final String CHARSET_PREFIX = "charset=";
-
-    private transient String contextPath;
-    private transient String servletPath;
-    private transient String uri;
-    private transient Map<String, String[]> params;
-    private transient String method = "GET";
-    private transient String contentType;
-    private transient String characterEncoding;
-    private transient byte[] content;
-    private transient ServletInputStream inputStream;
-
-    private final Map<String, HeaderValueHolder> headers = new LinkedCaseInsensitiveMap<>();
     private static final ServletInputStream EMPTY_SERVLET_INPUT_STREAM =
             new DelegatingServletInputStream(StreamUtils.emptyInput());
 
-    public ArtificialHttpServletRequest(String contextPath, String servletPath, String uri) {
+    // ---------------------------------------------------------------------
+    // ServletRequest properties
+    // ---------------------------------------------------------------------
+
+    private final Map<String, Object> attributes = new LinkedHashMap<>();
+    private transient String characterEncoding;
+    private transient String contentType;
+    private transient byte[] content;
+    private transient ServletInputStream inputStream;
+    private transient Map<String, String[]> parameters;
+
+    // ---------------------------------------------------------------------
+    // HttpServletRequest properties
+    // ---------------------------------------------------------------------
+
+    private transient String contextPath;
+    private transient String servletPath;
+    private transient String requestURI;
+    private transient String method = "GET";
+    private final Map<String, HeaderValueHolder> headers = new LinkedCaseInsensitiveMap<>();
+
+    public ArtificialHttpServletRequest(String contextPath, String servletPath, String requestURI) {
         this.contextPath = contextPath;
         this.servletPath = servletPath;
-        this.uri = uri;
+        this.requestURI = requestURI;
     }
 
     @Override
@@ -55,7 +64,7 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getRequestURI() {
-        return uri;
+        return requestURI;
     }
 
     @Override
@@ -66,7 +75,7 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
     @Override
     public String getParameter(String name) {
         Assert.notNull(name, "Parameter name must not be null");
-        String[] arr = this.params.get(name);
+        String[] arr = this.parameters.get(name);
         return arr != null && arr.length > 0 ? arr[0] : null;
     }
 
@@ -82,12 +91,12 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
     @Override
     public String[] getParameterValues(String name) {
         Assert.notNull(name, "Parameter name must not be null");
-        return this.params.get(name);
+        return this.parameters.get(name);
     }
 
     @Override
     public Enumeration<String> getParameterNames() {
-        return Collections.enumeration(this.params.keySet());
+        return Collections.enumeration(this.parameters.keySet());
     }
 
     public void setContentType(String contentType) {
@@ -186,8 +195,13 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
         return this.characterEncoding;
     }
 
-    public void setParams(Map<String, String[]> params) {
-        this.params = params;
+    public void setParameters(Map<String, String[]> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException();
     }
 
     // Below methods not implement
@@ -370,11 +384,6 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public void setAttribute(String name, Object o) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void removeAttribute(String name) {
         throw new UnsupportedOperationException();
     }
 

--- a/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
+++ b/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
@@ -370,93 +370,93 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public void setAttribute(String name, Object o) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void removeAttribute(String name) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Locale getLocale() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Enumeration<Locale> getLocales() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isSecure() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public RequestDispatcher getRequestDispatcher(String path) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     @Deprecated
     public String getRealPath(String path) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getRemotePort() {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getLocalName() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getLocalAddr() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getLocalPort() {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public ServletContext getServletContext() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public AsyncContext startAsync() throws IllegalStateException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isAsyncStarted() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isAsyncSupported() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public AsyncContext getAsyncContext() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public DispatcherType getDispatcherType() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
+++ b/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
@@ -208,178 +208,178 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getAuthType() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Cookie[] getCookies() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public long getDateHeader(String name) {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getIntHeader(String name) {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getPathInfo() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getPathTranslated() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getQueryString() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getRemoteUser() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isUserInRole(String role) {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getRequestedSessionId() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public StringBuffer getRequestURL() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public HttpSession getSession(boolean create) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public HttpSession getSession() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String changeSessionId() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isRequestedSessionIdValid() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isRequestedSessionIdFromCookie() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isRequestedSessionIdFromURL() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     @Deprecated
     public boolean isRequestedSessionIdFromUrl() {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void login(String username, String password) throws ServletException {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void logout() throws ServletException {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Collection<Part> getParts() throws IOException, ServletException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Part getPart(String name) throws IOException, ServletException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> httpUpgradeHandlerClass) throws IOException, ServletException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Object getAttribute(String name) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Enumeration<String> getAttributeNames() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Map<String, String[]> getParameterMap() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getProtocol() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getScheme() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getServerName() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getServerPort() {
-        return 0;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public BufferedReader getReader() throws IOException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getRemoteAddr() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public String getRemoteHost() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
+++ b/modules/raw-materials/roll-web/src/main/java/io/github/springroll/web/request/ArtificialHttpServletRequest.java
@@ -201,7 +201,23 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public void removeAttribute(String name) {
-        throw new UnsupportedOperationException();
+        Assert.notNull(name, "Attribute name must not be null");
+        this.attributes.remove(name);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return this.attributes.get(name);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        Assert.notNull(name, "Attribute name must not be null");
+        if (value != null) {
+            this.attributes.put(name, value);
+        } else {
+            this.attributes.remove(name);
+        }
     }
 
     // Below methods not implement
@@ -333,11 +349,6 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public Object getAttribute(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Enumeration<String> getAttributeNames() {
         throw new UnsupportedOperationException();
     }
@@ -379,11 +390,6 @@ public class ArtificialHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getRemoteHost() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setAttribute(String name, Object o) {
         throw new UnsupportedOperationException();
     }
 

--- a/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
+++ b/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
@@ -72,6 +72,16 @@ class ArtificialHttpServletRequestSpec extends Specification {
         'application/json'               | 'application/json'               | null
     }
 
+    def 'operate attribute'() {
+        request.setAttribute('a', '1')
+
+        expect:
+        request.getAttribute('a') == '1'
+        request.getAttribute('b') == null
+        request.removeAttribute('a')
+        request.getAttribute('a') ==  null
+    }
+
     def 'not support methods'() {
         def exclude = [
                 'getContextPath',
@@ -93,8 +103,12 @@ class ArtificialHttpServletRequestSpec extends Specification {
                 'getHeader',
                 'getHeaders',
                 'getHeaderNames',
+                'setCharacterEncoding',
                 'getCharacterEncoding',
-                'setParams',
+                'setParameters',
+                'removeAttribute',
+                'getAttribute',
+                'setAttribute',
                 '$jacocoInit'
         ]
 
@@ -109,16 +123,11 @@ class ArtificialHttpServletRequestSpec extends Specification {
             } else {
                 Arrays.fill(params, null)
             }
-            switch (method.getReturnType().getSimpleName()) {
-                case 'boolean':
-                    method.invoke(request, params) == false
-                    break
-                case 'long':
-                case 'int':
-                    method.invoke(request, params) == 0
-                    break
-                default:
-                    method.invoke(request, params) == null
+
+            try {
+                method.invoke(request, params)
+            } catch (Exception e) {
+                true
             }
         }
     }

--- a/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
+++ b/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
@@ -74,6 +74,8 @@ class ArtificialHttpServletRequestSpec extends Specification {
 
     def 'operate attribute'() {
         request.setAttribute('a', '1')
+        request.setAttribute('b', '2')
+        request.setAttribute('b', null)
 
         expect:
         request.getAttribute('a') == '1'

--- a/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
+++ b/modules/raw-materials/roll-web/src/test/groovy/io/github/springroll/web/ArtificialHttpServletRequestSpec.groovy
@@ -16,7 +16,7 @@ class ArtificialHttpServletRequestSpec extends Specification {
 
 
     def setup() {
-        request.setParams(params)
+        request.setParameters(params)
     }
 
     def 'check useful getters'() {


### PR DESCRIPTION
1. 所有未实现的方法抛出 `UnsupportedOperationException ` 异常，与 javadoc 中描述保持一致，方便尽快感知 ArtificialHttpServletRequest 中可能会被用到、需要实现的方法
1. 在实现了 attributes 相关方法后，支持了通用导出 Excel 功能实际调用的业务方法接口中包括 `@PathVariable` 的情况